### PR TITLE
Ammend prior makeflags pull request to allow -e to do its thing.

### DIFF
--- a/scripts/000-build-toolchain.sh
+++ b/scripts/000-build-toolchain.sh
@@ -17,7 +17,8 @@ LIBURING_DIR=liburing-2.4
 GCC_LIBS_DIR=gcc
 MUSL_LIBS_DIR=musl
 
-export MAKEFLAGS="-j$(nproc) -l$(nproc)"
+MAKEFLAGS="-j$(nproc) -l$(nproc)"
+export MAKEFLAGS
 
 DONE_MARKER=.done
 


### PR DESCRIPTION
I don't think this is really needed as nproc has been on every system I've used for over a decade but whatever.

Sorry for the double pull request!