### PR TITLE
Send term signal to entire process group on exit.

### DIFF
--- a/src/media/main.c
+++ b/src/media/main.c
@@ -414,6 +414,8 @@ main(int argc, char **argv)
     
     // TODO: properly wait for all children to terminate
     
+    killpg(0, SIGTERM);
+
     log_info("Shutting down... Bye!\n");
     
     queue_finalize(&server.queue);


### PR DESCRIPTION
Right now the media server leaves a bunch of processes hanging on exit.